### PR TITLE
Timezone handling, systemd detection and version detection fix

### DIFF
--- a/config.php
+++ b/config.php
@@ -11,10 +11,10 @@ $logpath = "/opt/direwolf/log/"; //path of the direwolf log directory, without f
 $logname = ""; //log file name. If empty, the standard Y-m-d.log file name (generated every day by direwolf) will be used.
 
 //interfaces index declared in direwolf conf file. Indexes separated by commas
-$interfaces=array(0);
+$interfaces=array(0,1);
 
 //interface descriptions. Insert strings between "" and separated by commas
-$intdesc=array("144.800  Warszawa East");
+$intdesc=array("144.800  VHF Port","432.500 UHF Port");
 
 //static_if skips interface choice every time
 $static_if = 1; //1 to enable static interface 

--- a/config.php
+++ b/config.php
@@ -3,23 +3,26 @@
 Configuration file for Direwolf SimpleWebstat.
 ********************************************************/
 
+//timezone
+$timezone = "Europe/Warsaw";
+
 $version = "0.1beta";
-$logpath = "/var/log/direwolf/"; //path of the direwolf log directory, without file name
+$logpath = "/opt/direwolf/log/"; //path of the direwolf log directory, without file name
 $logname = ""; //log file name. If empty, the standard Y-m-d.log file name (generated every day by direwolf) will be used.
 
 //interfaces index declared in direwolf conf file. Indexes separated by commas
-$interfaces=array(0,1);
+$interfaces=array(0);
 
 //interface descriptions. Insert strings between "" and separated by commas
-$intdesc=array("144.800  VHF Port","432.500 UHF Port");
+$intdesc=array("144.800  Warszawa East");
 
 //static_if skips interface choice every time
 $static_if = 1; //1 to enable static interface 
 $static_if_index = 0; //interface index when static_if is enabled
 
 //station posistion data for calculating distance from received station
-$stationlat = 41.248027; //station latitude in decimal degrees
-$stationlon = 16.421246;  //station longtitude in decimal degrees
+$stationlat = 52.00000; //station latitude in decimal degrees
+$stationlon = 21.00000;  //station longtitude in decimal degrees
 
 //logo path,with file name, shown on the top of the page
 $logourl="direwolf.png";

--- a/summary.php
+++ b/summary.php
@@ -12,7 +12,7 @@ include 'functions.php';
 if(file_exists('custom.php')) include 'custom.php';
 
 logexists();
-  
+
 session_start(); //start session
 if(!isset($_SESSION['if'])) { //if interface not defined
    	header('Refresh: 0; url=chgif.php?chgif=1');
@@ -69,10 +69,11 @@ $if = $_SESSION['if'];
          $cputemp     = NULL;
          $cpufreq     = NULL;
          $uptime      = NULL;
+         $direwolfsts = NULL;
          
          $sysver = shell_exec ("cat /etc/os-release | grep PRETTY_NAME |cut -d '=' -f 2");
          $kernelver = shell_exec ("uname -r");
-         $direwolfver = shell_exec ("direwolf --v | grep -m 1 'version' | cut -d ' ' -f 4");
+         $direwolfver = shell_exec ("direwolf --v | grep -m 1 'version' | cut -d ' ' -f 5");
          if (file_exists ("/sys/class/thermal/thermal_zone0/temp")) {
              exec("cat /sys/class/thermal/thermal_zone0/temp", $cputemp);
              $cputemp = $cputemp[0] / 1000;
@@ -82,6 +83,7 @@ $if = $_SESSION['if'];
          	$cpufreq = $cpufreq[0] / 1000;
          }
          $uptime = shell_exec('uptime -p');
+         $direwolfsts = shell_exec('systemctl is-active direwolf');
 		?>
         
       <br>
@@ -114,6 +116,10 @@ $if = $_SESSION['if'];
             <tr>
                <td bgcolor="silver" style="width: 200px;"><b>CPU frequency: </b></td>
                <td style="width: 400px;"><?php echo $cpufreq ?> MHz </td>
+            </tr>
+            <tr>
+               <td bgcolor="silver" style="width: 200px;"><b>Direwolf status: </b></td>
+               <td style="width: 400px;"><?php if(str_starts_with($direwolfsts, "active")) echo("<span style=\"color:green\"><b>Working</b></span>"); else echo("<span style=\"color:red\"><b>Not working</b></span>"); ?> </td>
             </tr>
          </tbody>
       </table>
@@ -209,8 +215,12 @@ $if = $_SESSION['if'];
                </td>
                <td align="center">
                   <?php
-                     echo(date('m/d/Y H:i:s', $nm[1]))
-                     ?>
+                     //echo(date('d/m/Y H:i:s', $nm[1]));
+                     $date = new DateTimeImmutable();
+		     $date = $date->setTimestamp($nm[1]);
+	             $date = $date->setTimezone(new DateTimeZone($timezone));
+		     echo($date->format('H:i:s d/m/Y'));
+	          ?>
                </td>
                <td align="center">
                   <?php


### PR DESCRIPTION
This pull request fixes:

- Timezone and date display. Now it handles UTC timestamps with timezone configurable in config.php.
- Version detection. It now shows ex. 1.8 not just "version".

Also adds one feature:

- It detects if direwolf service is running via systemd. Systemd is now a day standard init so I didn't add support to other init systems.

This webpanel need total rewrite to modern PHP and separate frontend and backend not everything in one file. But it works and it is very VERY simple to add features and fix. I like it! 